### PR TITLE
Fixes #2 and dont add when existing static displayName

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Typescript transformer that adds displayName to React components.
 ### Installation
 
 Install the library:
+
 ```bash
 npm install --save-dev ts-react-display-name
 ```
@@ -17,11 +18,13 @@ npm install --save-dev ts-react-display-name
 ### Webpack
 
 If you are using Webpack, import the tranformer:
+
 ```js
 const { addDisplayNameTransformer } = require('ts-react-display-name')
 ```
 
 Then add it to ts-loader's options:
+
 ```js
 {
   test: /\.(tsx?)$/,
@@ -34,10 +37,10 @@ Then add it to ts-loader's options:
 }
 ```
 
-
 ## Example
 
 Using this transformer, the following code:
+
 ```js
 // Function component
 const TestFuncComponent: React.FC<{}> = () => <p>...</p>
@@ -49,6 +52,7 @@ export class TestComponent extends React.Component<{}, {}> {
 ```
 
 Becomes:
+
 ```js
 // Function component
 const TestFuncComponent: React.FC<{}> = () => <p>...</p>
@@ -60,7 +64,6 @@ export class TestComponent extends React.Component<{}, {}> {
   render() { ... }
 }
 ```
-
 
 ## Advanced
 
@@ -77,14 +80,14 @@ worth it.
 
 ```js
 addDisplayNameTransformer({
-  onlyFileRoot: true
+  onlyFileRoot: true,
 })
 ```
 
 #### funcTypes
 
 List of function types to add displayName to. Display names will only be added
-to functions *explicitly* typed with one of those.
+to functions _explicitly_ typed with one of those.
 
 If you import React as "R" then you will have to update this list to be
 ['R.FunctionComponent', 'R.FC']. This list needs to match exactly what is
@@ -94,14 +97,14 @@ in the source code.
 
 ```js
 addDisplayNameTransformer({
-  funcTypes: ['React.FunctionComponent', 'React.FC']
+  funcTypes: ['React.FunctionComponent', 'React.FC'],
 })
 ```
 
 #### classTypes
 
 List of class types to add displayName to. Display names will only be added
-to classes *explicitly* extending one of those.
+to classes _explicitly_ extending one of those.
 
 If you import React as "R" then you will have to update this list to be
 ['R.Component', 'R.PureComponent']. This list needs to match exactly what is
@@ -111,22 +114,26 @@ in the source code.
 
 ```js
 addDisplayNameTransformer({
-  classTypes: ['React.Component', 'React.PureComponent']
+  classTypes: ['React.Component', 'React.PureComponent'],
 })
 ```
-
 
 ## Contributing to this project
 
 Feel free to contribute to this project and submit pull requests.
 
 Here are a couple useful commands:
+
 - `npm run test`: Runs tests and linters.
 - `npm run build`: Builds the library.
 
+### Adding Unit test data
+
+1. Add your origin test data file as `/test/data/xxx.tsx`
+2. Paste your raw `/test/data/xxx.tsx` file into [Typescript Playround](https://www.typescriptlang.org/play/index.html?target=1&jsx=2) using the link settings, then add the displayName (function or static property) and save the generated output to `test/data/xxx.ts`
 
 ## TODOs
 
 - Try to find a better way to compare types (without converting to text
-using getText(sourceFile))
+  using getText(sourceFile))
 - Optionally detect if there is already a displayName and don't override it.

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+const path = require("path");
 const ts = require("typescript");
 /**
  * Creates an assignment statement. We assign the name of the given node to the property displayName
@@ -14,7 +15,8 @@ const createSetDisplayNameStatement = (node, sf) => {
  * Creates a static class property named "displayName" and with value the name of the class.
  */
 const createDisplayNameProperty = (node, sf) => {
-    const name = ts.getNameOfDeclaration(node).getText(sf);
+    const declaration = ts.getNameOfDeclaration(node);
+    const name = declaration ? declaration.getText(sf) : path.parse(sf.fileName).name;
     return ts.createProperty(undefined, ts.createModifiersFromModifierFlags(ts.ModifierFlags.Static), 'displayName', undefined, undefined, ts.createStringLiteral(name));
 };
 /**

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "test": "npm run lint && npm run unit-tests && npm run prettier-check",
     "unit-tests": "mocha --require ts-node/register test/{**/,}*-test.ts",
     "lint": "tslint -c tslint.json src/**/* test/**/*",
-    "prettier-check": "prettier --config .prettierrc --check '{{src,test}/**/*,*}.ts'",
-    "prettier": "prettier --config .prettierrc --write '{{src,test}/**/*,*}.ts'",
+    "prettier-check": "prettier --config .prettierrc --check \"{{src,test}/**/*,*}.ts\"",
+    "prettier": "prettier --config .prettierrc --write \"{{src,test}/**/*,*}.ts\"",
     "build": "tsc",
     "watch-tests": "mocha --watch --compilers ts:ts-node/register test/{**/,}*-test.ts",
     "clean": "rm -fr dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import * as ts from 'typescript'
 
 export interface AddDisplayNameOptions {
@@ -34,7 +35,8 @@ const createSetDisplayNameStatement = (node: ts.VariableDeclaration, sf: ts.Sour
  * Creates a static class property named "displayName" and with value the name of the class.
  */
 const createDisplayNameProperty = (node: ts.ClassDeclaration, sf: ts.SourceFile) => {
-  const name = ts.getNameOfDeclaration(node).getText(sf)
+  const declaration = ts.getNameOfDeclaration(node)
+  const name: string = declaration ? declaration.getText(sf) : path.parse(sf.fileName).name
   return ts.createProperty(
     undefined,
     ts.createModifiersFromModifierFlags(ts.ModifierFlags.Static),

--- a/test/data/react-comp-existing.ts
+++ b/test/data/react-comp-existing.ts
@@ -1,0 +1,26 @@
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+import * as React from 'react';
+var TestComponent = /** @class */ (function (_super) {
+    __extends(TestComponent, _super);
+    function TestComponent() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    TestComponent.prototype.render = function () {
+        return React.createElement("p", null, "returned value");
+    };
+    TestComponent.displayName = 'TestComponent';
+    return TestComponent;
+}(React.Component));
+export { TestComponent };

--- a/test/data/react-comp-existing.tsx
+++ b/test/data/react-comp-existing.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+
+export class TestComponent extends React.Component<{}, {}> {
+  static displayName = 'TestComponent'
+  render() {
+    return <p>returned value</p>
+  }
+}

--- a/test/data/react-comp-unamed-default.ts
+++ b/test/data/react-comp-unamed-default.ts
@@ -1,0 +1,26 @@
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+import * as React from 'react';
+var default_1 = /** @class */ (function (_super) {
+    __extends(default_1, _super);
+    function default_1() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    default_1.prototype.render = function () {
+        return React.createElement("p", null, "returned value");
+    };
+    return default_1;
+}(React.Component));
+export default default_1;
+default_1.displayName = "react-comp-unamed-default";

--- a/test/data/react-comp-unamed-default.tsx
+++ b/test/data/react-comp-unamed-default.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react'
+
+export default class extends React.Component<{}, {}> {
+  render() {
+    return <p>returned value</p>
+  }
+}

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -74,4 +74,9 @@ describe('index.ts', () => {
     })
     expect(result.outputText).to.equal(file('react-comp-unamed-default.ts'))
   })
+
+  it('does not add displayName to classes extending React.Component with static displayName', () => {
+    const result = ts.transpileModule(file('react-comp-existing.tsx'), options)
+    expect(result.outputText).to.equal(file('react-comp-existing.ts'))
+  })
 })

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -66,4 +66,12 @@ describe('index.ts', () => {
     const result = ts.transpileModule(file('pure-comp.tsx'), options)
     expect(result.outputText).to.equal(file('pure-comp.ts'))
   })
+
+  it('adds displayName to unamed default classes extending React.Component', () => {
+    const result = ts.transpileModule(file('react-comp-unamed-default.tsx'), {
+      ...options,
+      fileName: 'react-comp-unamed-default.tsx',
+    })
+    expect(result.outputText).to.equal(file('react-comp-unamed-default.ts'))
+  })
 })

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -16,54 +16,54 @@ describe('index.ts', () => {
   const options = makeOptions()
 
   it('adds displayName to FunctionComponent', () => {
-    let result = ts.transpileModule(file('func-comp.tsx'), options)
+    const result = ts.transpileModule(file('func-comp.tsx'), options)
     expect(result.outputText).to.equal(file('func-comp.ts'))
   })
 
   it('adds displayName to FC (shortcut for FunctionComponent)', () => {
-    let result = ts.transpileModule(file('fc-comp.tsx'), options)
+    const result = ts.transpileModule(file('fc-comp.tsx'), options)
     expect(result.outputText).to.equal(file('func-comp.ts'))
   })
 
   it('adds displayName to many FunctionComponent', () => {
-    let result = ts.transpileModule(file('func-comp-multi.tsx'), options)
+    const result = ts.transpileModule(file('func-comp-multi.tsx'), options)
     expect(result.outputText).to.equal(file('func-comp-multi.ts'))
   })
 
   it('adds displayName to nested FunctionComponent', () => {
-    let result = ts.transpileModule(file('func-comp-nested.tsx'), options)
+    const result = ts.transpileModule(file('func-comp-nested.tsx'), options)
     expect(result.outputText).to.equal(file('func-comp-nested.ts'))
   })
 
   it('does not add displayName to nested FunctionComponent if onlyFileRoot is set', () => {
     const onlyRootOptions = makeOptions({ onlyFileRoot: true })
-    let result = ts.transpileModule(file('func-comp-nested.tsx'), onlyRootOptions)
+    const result = ts.transpileModule(file('func-comp-nested.tsx'), onlyRootOptions)
     expect(result.outputText).to.equal(file('func-comp-nested-only-root.ts'))
   })
 
   it('adds displayName to classes extending React.Component', () => {
-    let result = ts.transpileModule(file('react-comp.tsx'), options)
+    const result = ts.transpileModule(file('react-comp.tsx'), options)
     expect(result.outputText).to.equal(file('react-comp.ts'))
   })
 
   it('adds displayName to classes extending React.Component containing other static prop', () => {
-    let result = ts.transpileModule(file('react-comp-other-static.tsx'), options)
+    const result = ts.transpileModule(file('react-comp-other-static.tsx'), options)
     expect(result.outputText).to.equal(file('react-comp-other-static.ts'))
   })
 
   it('adds displayName to classes extending React.Component nested', () => {
-    let result = ts.transpileModule(file('react-comp-nested.tsx'), options)
+    const result = ts.transpileModule(file('react-comp-nested.tsx'), options)
     expect(result.outputText).to.equal(file('react-comp-nested.ts'))
   })
 
   it('does not add displayName to classes extending React.Component nested if onlyFileRoot is set', () => {
     const onlyRootOptions = makeOptions({ onlyFileRoot: true })
-    let result = ts.transpileModule(file('react-comp-nested.tsx'), onlyRootOptions)
+    const result = ts.transpileModule(file('react-comp-nested.tsx'), onlyRootOptions)
     expect(result.outputText).to.equal(file('react-comp-nested-only-root.ts'))
   })
 
   it('adds displayName to classes extending React.PureComponent', () => {
-    let result = ts.transpileModule(file('pure-comp.tsx'), options)
+    const result = ts.transpileModule(file('pure-comp.tsx'), options)
     expect(result.outputText).to.equal(file('pure-comp.ts'))
   })
 })


### PR DESCRIPTION
* Fix for issue #2   `export default class extends React.Component`  Im defaulting to the filename excluding ext.

* Dont add a `static displayName` to class components if it already exists.  I dont know enough about the Typescript API to do the same for functional components.

* Couple of other small lint fixes for existing codebase.
