### PR TITLE
fix isStaticDisplayNameDefined error #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ Here are a couple useful commands:
 
 - Try to find a better way to compare types (without converting to text
   using getText(sourceFile))
-- Optionally detect if there is already a displayName and don't override it.
+- Optionally detect if there is already a displayName for functional componments and don't override it.

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,14 +88,19 @@ const isReactComponent = (
  */
 function isStaticDisplayNameDefined(classDeclaration: ts.ClassDeclaration): boolean {
   return (
-    classDeclaration.members.find(
-      member =>
-        member.name.getText() === 'displayName' &&
-        member.kind === ts.SyntaxKind.PropertyDeclaration &&
-        member.modifiers.some(
-          modifier => (modifier.kind & ts.ModifierFlags.Static) === ts.ModifierFlags.Static
+    classDeclaration.members.find(member => {
+      try {
+        return (
+          member.kind === ts.SyntaxKind.PropertyDeclaration &&
+          member.modifiers.some(
+            modifier => (modifier.kind & ts.ModifierFlags.Static) === ts.ModifierFlags.Static
+          ) &&
+          (member.name as ts.Identifier).text === 'displayName'
         )
-    ) !== undefined
+      } catch (e) {
+        return false
+      }
+    }) !== undefined
   )
 }
 

--- a/test/data/react-comp-multiple.ts
+++ b/test/data/react-comp-multiple.ts
@@ -1,0 +1,47 @@
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+import * as React from 'react';
+var TestComponent = /** @class */ (function (_super) {
+    __extends(TestComponent, _super);
+    function TestComponent() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    TestComponent.prototype.render = function () {
+        return React.createElement("p", null, "returned value");
+    };
+    TestComponent.displayName = "TestComponent";
+    return TestComponent;
+}(React.Component));
+var TestComponentA = /** @class */ (function (_super) {
+    __extends(TestComponentA, _super);
+    function TestComponentA() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    TestComponentA.prototype.render = function () {
+        return React.createElement("p", null, "returned value");
+    };
+    TestComponentA.displayName = "TestComponentA";
+    return TestComponentA;
+}(React.Component));
+var TestComponentB = /** @class */ (function (_super) {
+    __extends(TestComponentB, _super);
+    function TestComponentB() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    TestComponentB.prototype.render = function () {
+        return React.createElement("p", null, "returned value");
+    };
+    TestComponentB.displayName = 'TestComponentB';
+    return TestComponentB;
+}(React.Component));

--- a/test/data/react-comp-multiple.tsx
+++ b/test/data/react-comp-multiple.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+
+class TestComponent extends React.Component<{}, {}> {
+  render() {
+    return <p>returned value</p>
+  }
+}
+
+class TestComponentA extends React.Component<{}> {
+  render() {
+    return <p>returned value</p>
+  }
+}
+
+class TestComponentB extends React.Component<{}> {
+  static displayName = 'TestComponentB'
+  render() {
+    return <p>returned value</p>
+  }
+}

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -46,6 +46,11 @@ describe('index.ts', () => {
     expect(result.outputText).to.equal(file('react-comp.ts'))
   })
 
+  it('adds displayName to mulitple classes extending React.Component', () => {
+    const result = ts.transpileModule(file('react-comp-multiple.tsx'), options)
+    expect(result.outputText).to.equal(file('react-comp-multiple.ts'))
+  })
+
   it('adds displayName to classes extending React.Component containing other static prop', () => {
     const result = ts.transpileModule(file('react-comp-other-static.tsx'), options)
     expect(result.outputText).to.equal(file('react-comp-other-static.ts'))


### PR DESCRIPTION
PR to fix issue #6 

`isStaticDisplayNameDefined` was throwing error in a file that contain lots of components, it was a file I was using for integration testing of ts-react-display-name, so not a normal pattern.

In the case `isStaticDisplayNameDefined` does throw an exception i am returning false so it will create static property, your call on this.  Not sure if to console.log the warning/error